### PR TITLE
Use a dedicated logging channel by default

### DIFF
--- a/Handler/EmbeddedShortcodeHandler.php
+++ b/Handler/EmbeddedShortcodeHandler.php
@@ -59,7 +59,7 @@ class EmbeddedShortcodeHandler
      */
     public function __invoke(ShortcodeInterface $shortcode)
     {
-        $this->logger->notice(
+        $this->logger->info(
             'Request {controllerName} with parameters {parameters} and renderer {renderer} to resolve shortcode {shortcode}, triggered by a request to {url}.',
             [
                 'controllerName' => $this->controllerName,

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ comment:
 In analogy to living style guides, this bundle also provides an optional shortcode guide. This guide can be used for
 automated testing of your shortcodes as well. 
  
-
 ## Installation
 
 As usual, install via [composer](https://getcomposer.org/) and register the bundle in your application:
@@ -54,7 +53,6 @@ public function registerBundles()
     // ...
 }
 ```
-
 
 ## Usage
 
@@ -158,7 +156,6 @@ And finally a twig template like this:
 </div>
 ```
 
-
 ### Activating the Shortcode Guide
 
 The optional shortcode guide is a controller providing an overview page of the configured shortcodes and a detail page
@@ -214,7 +211,6 @@ Finally, enrich your shortcode tags with description and example attributes for 
 
 With the route prefix defined as above, call ```/shortcodes/``` to get the list of shortcodes and follow the links to the
 detail pages.
-
 
 ### Automated Tests for your Shortcodes
 
@@ -275,7 +271,6 @@ final class ImageTest extends ShortcodeTest
 }
 ```
 
-
 ## Logging
 
 When something goes wrong with the resolving of a shortcode, maybe you not only want to know which shortcode with
@@ -284,9 +279,7 @@ that embedded the shortcode.
 
 This is tricky is you embed your shortcode controllers via ESI, as the ESI subrequest is in Symfony terms a master
 request, preventing you from getting your answer from RequestStack::getMasterRequest(). Hence, the
-`EmbedShortcodeHandler` logs with the default monolog handler which controller it will call to resolve the shortcode.
-You can overwrite the `EmbedShortcodeHandler`'s logger, e.g. if you want to change the channel, in the service
-definition of your shortcode:
+`EmbedShortcodeHandler` logs this information in the `shortcode` channel.
 
 ```xml
 <!-- src/AppBundle/Resources/config/shortcodes.xml -->
@@ -304,12 +297,11 @@ definition of your shortcode:
 </container>
 ```
 
-
 ## Credits, Copyright and License
 
 This bundle was started at webfactory GmbH, Bonn.
 
-- <http://www.webfactory.de>
-- <http://twitter.com/webfactory>
+- <https://www.webfactory.de>
+- <https://twitter.com/webfactory>
 
-Copyright 2018 webfactory GmbH, Bonn. Code released under [the MIT license](LICENSE).
+Copyright 2018-2021 webfactory GmbH, Bonn. Code released under [the MIT license](LICENSE).

--- a/Resources/config/shortcodes.xml
+++ b/Resources/config/shortcodes.xml
@@ -35,6 +35,7 @@
             <argument>esi</argument>
             <argument type="service" id="request_stack" />
             <argument type="service" id="logger" on-invalid="null" />
+            <tag name="monolog.logger" channel="shortcode" />
         </service>
 
         <!-- alias for BC -->
@@ -47,6 +48,7 @@
             <argument>inline</argument>
             <argument type="service" id="request_stack" />
             <argument type="service" id="logger" on-invalid="null" />
+            <tag name="monolog.logger" channel="shortcode" />
         </service>
 
         <!-- alias for BC -->


### PR DESCRIPTION
We should use a dedicated logging channel by default. 

- Its easier to redirect or disable logging information for this bundle when
  it is using a dedicated channel. No need for extra service configuration
  as previously described in the README.

- For most people and Symfony default configurations, all channels should be
  handled, so this might not even be a problem from a BC point of view.

