### PR TITLE
Make the parser type, iteration count and recursion limit configurable

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Webfactory\ShortcodeBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder('webfactory_shortcode');
+
+        $treeBuilder->getRootNode()
+            ->children()
+                ->enumNode('parser')
+                    ->info('Which parser type to use, choose "regular" or "regex".')
+                    ->values(['regular', 'regex'])
+                    ->defaultValue('regular')
+                ->end()
+                ->integerNode('recursion_depth')
+                    ->info('Controls how many levels of shortcodes to process')
+                    ->defaultValue(null)
+                ->end()
+                ->integerNode('max_iterations')
+                    ->info('Limit the number of iterations when resolving shortcodes')
+                    ->defaultValue(null)
+                ->end()
+        ;
+
+        return $treeBuilder;
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -11,6 +11,8 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('webfactory_shortcode');
 
+        // For details on these configuration options, see https://github.com/thunderer/Shortcode#parsing and
+        // https://github.com/thunderer/Shortcode#configuration .
         $treeBuilder->getRootNode()
             ->children()
                 ->enumNode('parser')

--- a/DependencyInjection/WebfactoryShortcodeExtension.php
+++ b/DependencyInjection/WebfactoryShortcodeExtension.php
@@ -2,10 +2,11 @@
 
 namespace Webfactory\ShortcodeBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Thunder\Shortcode\Processor\Processor;
 
 /**
  * Loads the bundle configuration.
@@ -16,5 +17,14 @@ final class WebfactoryShortcodeExtension extends Extension
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('shortcodes.xml');
+
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $container->setAlias('webfactory_shortcode.parser', 'webfactory_shortcode.'.$config['parser'].'_parser');
+
+        $container->getDefinition(Processor::class)
+            ->addMethodCall('withRecursionDepth', [$config['recursion_depth']])
+            ->addMethodCall('withMaxIterations', [$config['max_iterations']]);
     }
 }

--- a/README.md
+++ b/README.md
@@ -216,6 +216,22 @@ With the route prefix defined as above, call ```/shortcodes/``` to get the list 
 detail pages.
 
 
+### Configuration
+
+In most cases, the default values should work fine. But you might want to configure something else, e.g. if the default
+parser needs too much memory for a large snippet. See thunderer's documentation on [parsing](https://github.com/thunderer/Shortcode#parsing)
+and [configuration](https://github.com/thunderer/Shortcode#configuration) so you understand the advantages,
+disadvantages and limitations:
+
+```yaml
+// config.yml
+
+webfactory_shortcode:
+    parser: 'regex'      # default: regular
+    recursion_depth: 2   # default: null
+    max_iterations: 2    # default: null
+```  
+
 ### Automated Tests for your Shortcodes
 
 With the shortcode guide enabled (remember: you may enable it just in your test environment), you can easily write

--- a/Resources/config/shortcodes.xml
+++ b/Resources/config/shortcodes.xml
@@ -8,13 +8,16 @@
         <!-- Definition of a Shortcode HandlerContainer instance. -->
         <service id="Thunder\Shortcode\HandlerContainer\HandlerContainer"/>
 
-        <!-- Definition of a Shortcode RegularParser instance. -->
-        <service id="Thunder\Shortcode\Parser\RegularParser"/>
+        <service id="webfactory_shortcode.regular_parser" class="Thunder\Shortcode\Parser\RegularParser"/>
+        <service id="webfactory_shortcode.regex_parser" class="Thunder\Shortcode\Parser\RegexParser"/>
 
         <!-- Definition of a Shortcode Processor instance. -->
         <service id="Thunder\Shortcode\Processor\Processor">
-            <argument type="service" id="Thunder\Shortcode\Parser\RegularParser" />
+            <argument type="service" id="webfactory_shortcode.parser" />
             <argument type="service" id="Thunder\Shortcode\HandlerContainer\HandlerContainer" />
+            <call method="withEventContainer">
+                <argument type="service" id="Thunder\Shortcode\EventContainer\EventContainer" />
+            </call>
         </service>
 
         <!-- Definition of a Shortcode EventContainer instance. -->
@@ -55,7 +58,6 @@
         <!-- Twig extension providing the |shortcodes filter. The content will be passed to the Shortcode Processor. -->
         <service id="Webfactory\ShortcodeBundle\Twig\ShortcodeExtension" class="Webfactory\ShortcodeBundle\Twig\ShortcodeExtension">
             <argument type="service" id="Thunder\Shortcode\Processor\Processor"/>
-            <argument type="service" id="Thunder\Shortcode\EventContainer\EventContainer"/>
             <tag name="twig.extension"/>
         </service>
 

--- a/Twig/ShortcodeExtension.php
+++ b/Twig/ShortcodeExtension.php
@@ -15,12 +15,9 @@ final class ShortcodeExtension extends AbstractExtension
     /** @var Processor */
     private $processor;
 
-    /**
-     * @param Processor $processor
-     */
-    public function __construct(Processor $processor, EventContainer $eventContainer)
+    public function __construct(Processor $processor)
     {
-        $this->processor = $processor->withMaxIterations(null)->withEventContainer($eventContainer);
+        $this->processor = $processor;
     }
 
     public function getFilters()


### PR DESCRIPTION
On complex pages, the `RegularParser` consumes a lot of memory. Using the `RegexParser` instead and possibly limiting the recursion depth and maximum iteration count might help.
