### PR TITLE
Only log url if master request exists

### DIFF
--- a/src/Handler/EmbeddedShortcodeHandler.php
+++ b/src/Handler/EmbeddedShortcodeHandler.php
@@ -63,7 +63,7 @@ class EmbeddedShortcodeHandler
                 'parameters' => json_encode($shortcode->getParameters()),
                 'renderer' => $this->renderer,
                 'shortcode' => $shortcode->getName(),
-                'url' => $this->requestStack->getMasterRequest()->getRequestUri(),
+                'url' => $this->requestStack->getMasterRequest() ? $this->requestStack->getMasterRequest()->getRequestUri() : '-',
             ]
         );
 


### PR DESCRIPTION
If you use this class in your test suite (without any real request) you will recieve an error that the request does not exist. To prevent this, we need to check it before.