### PR TITLE
Führe GitHub Actions Workflows mit Ubuntu 20.04 aus

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ env:
 jobs:
     PHPUnit:
 
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-20.04
         strategy:
             fail-fast: false
             matrix:


### PR DESCRIPTION
Der für uns wesentliche Unterschied sollte die Verwendung von MySQL 8 sein. Auf diese Weise können wir testen, ob wir vorwärtskompatibel sind.
