### PR TITLE
Catch all errors thrown when generating shortcode replacements

### DIFF
--- a/src/Handler/EmbeddedShortcodeHandler.php
+++ b/src/Handler/EmbeddedShortcodeHandler.php
@@ -7,9 +7,9 @@ use Psr\Log\NullLogger;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
+use Throwable;
 use Thunder\Shortcode\Shortcode\ProcessedShortcode;
 use Thunder\Shortcode\Shortcode\ShortcodeInterface;
-use Throwable;
 
 /**
  * Handler for thunderer\Shortcode that embeds the configured renderer for a shortcode.
@@ -79,8 +79,9 @@ class EmbeddedShortcodeHandler
             if ($shortcode instanceof ProcessedShortcode) {
                 $text = trim($shortcode->getShortcodeText(), '[]');
             } else {
-                $text = $shortcode->getName() . ' ...';
+                $text = $shortcode->getName().' ...';
             }
+
             return "<code>&#91;$text&#93;</code>";
         }
     }

--- a/src/Handler/EmbeddedShortcodeHandler.php
+++ b/src/Handler/EmbeddedShortcodeHandler.php
@@ -82,6 +82,7 @@ class EmbeddedShortcodeHandler
                 $text = $shortcode->getName().' ...';
             }
 
+            // Avoid an infinite loop that occurs if the original shortcode is returned
             return "<code>&#91;$text&#93;</code>";
         }
     }

--- a/src/Handler/EmbeddedShortcodeHandler.php
+++ b/src/Handler/EmbeddedShortcodeHandler.php
@@ -7,7 +7,9 @@ use Psr\Log\NullLogger;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
+use Thunder\Shortcode\Shortcode\ProcessedShortcode;
 use Thunder\Shortcode\Shortcode\ShortcodeInterface;
+use Throwable;
 
 /**
  * Handler for thunderer\Shortcode that embeds the configured renderer for a shortcode.
@@ -66,9 +68,20 @@ class EmbeddedShortcodeHandler
             ]
         );
 
-        return $this->fragmentHandler->render(
-            new ControllerReference($this->controllerName, $shortcode->getParameters()),
-            $this->renderer
-        );
+        try {
+            return $this->fragmentHandler->render(
+                new ControllerReference($this->controllerName, $shortcode->getParameters()),
+                $this->renderer
+            );
+        } catch (Throwable $exception) {
+            $this->logger->error('An exception was thrown when rendering the shortcode', ['exception' => $exception]);
+
+            if ($shortcode instanceof ProcessedShortcode) {
+                $text = trim($shortcode->getShortcodeText(), '[]');
+            } else {
+                $text = $shortcode->getName() . ' ...';
+            }
+            return "<code>&#91;$text&#93;</code>";
+        }
     }
 }


### PR DESCRIPTION
When a controller that is used to generate shortcode replacements throws an Exception, this exeception will currently fall-through.

I think this kind of errors should be contained, and we should try to display the shortcode as unchanged as possible, as if we had not attempted to resolve it in the first place (of course, logging the problem).