### PR TITLE
Create client before booting the Kernel

### DIFF
--- a/tests/Functional/ShortcodeTest.php
+++ b/tests/Functional/ShortcodeTest.php
@@ -29,8 +29,8 @@ abstract class ShortcodeTest extends WebTestCase
             throw new PHPUnit_Framework_IncompleteTestError('Albeit being a '.__CLASS__.', '.static::class.' does not define a shortcode to test.');
         }
 
-        static::bootKernel();
         $this->client = static::createClient();
+        static::bootKernel();
     }
 
     /**


### PR DESCRIPTION
Since Symfony 5 booting the Kernel before creating the client ist not allowed anymore: https://github.com/symfony/framework-bundle/blob/ec8ac3e40fe2e6eb0984acd8e07d69a6655a7a5f/Test/WebTestCase.php#L40
