### PR TITLE
Vermeide Deprecation (Case 193321)

### DIFF
--- a/src/DependencyInjection/WebfactoryShortcodeExtension.php
+++ b/src/DependencyInjection/WebfactoryShortcodeExtension.php
@@ -5,8 +5,8 @@ namespace Webfactory\ShortcodeBundle\DependencyInjection;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * Loads the bundle configuration.


### PR DESCRIPTION
...durch Nutzung von `Symfony\Component\DependencyInjection\Extension\Extension` an Stelle von `Symfony\Component\HttpKernel\DependencyInjection\Extension`.
