### PR TITLE
Fix request parameter method call in `GuideController`

### DIFF
--- a/src/Controller/GuideController.php
+++ b/src/Controller/GuideController.php
@@ -63,7 +63,7 @@ final class GuideController
         $shortcodeTag = $this->shortcodeTags[$shortcode];
 
         // if custom parameters are provided, replace the example
-        $customParameters = $request->get('customParameters');
+        $customParameters = $request->query->get('customParameters');
         if ($customParameters) {
             $shortcodeTag['example'] = $shortcode.' '.$customParameters;
         }


### PR DESCRIPTION
The method [`$request->get()`](https://symfony.com/blog/new-in-symfony-7-4-request-class-improvements#deprecated-the-get-method) was removed in Symfony >= 8. Internal the method used either `$this->attributes->get()` or `$this->query->get()` or `$this->request->get()`. In this case we need to call `$request->query->get()`.